### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/bloomf.opam
+++ b/bloomf.opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml"   {>= "4.03.0"}
-  "dune"    {build & >= "1.7.0"}
+  "dune"    {>= "1.7.0"}
   "bitv"
   "alcotest" {with-test}
 ]


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.