### PR TITLE
Add bytes and string serializers

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version = 0.14.2
+version = 0.15.0
 parse-docstrings = true
 break-infix = fit-or-vertical

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
-## Unreleased 2020-08-26
+## Unreleased
 
-- Add serializers and deserializers: `to_string`, `to_bytes`, `of_string`, and `of_bytes`
+- Add serializers and deserializers: `to_bytes` and `of_bytes`
 
 ## v0.1.0 2019-03-07
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Unreleased 2020-08-26
+
+- Add serializers and deserializers: `to_string`, `to_bytes`, `of_string`, and `of_bytes`
+
 ## v0.1.0 2019-03-07
 
 - Initial release

--- a/bloomf.opam
+++ b/bloomf.opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml"   {>= "4.04.0"}
   "dune"    {>= "1.7.0"}
-  "bitv"
+  "bitv"    {>= "1.4"}
   "alcotest" {with-test}
 ]
 synopsis: "Efficient Bloom filters for OCaml"

--- a/bloomf.opam
+++ b/bloomf.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"   {>= "4.03.0"}
+  "ocaml"   {>= "4.04.0"}
   "dune"    {>= "1.7.0"}
   "bitv"
   "alcotest" {with-test}

--- a/src/bloomf.ml
+++ b/src/bloomf.ml
@@ -79,11 +79,15 @@ let size_estimate t =
   int_of_float (-.mf /. kf *. log (1. -. (xf /. mf)))
 
 let to_buf t =
-  let gs = String.make 1 (Char.chr 29) in
   let rs = String.make 1 (Char.chr 30) in
   let us = String.make 1 (Char.chr 31) in
   let buf =
     Buffer.create (5 + (4 * List.length t.p_len) + (2 * Bitv.length t.b))
+  in
+  let write_to_buf buf content =
+    Buffer.add_string buf (string_of_int (Bytes.length content));
+    Buffer.add_string buf "|";
+    Buffer.add_bytes buf content
   in
   let p_len_to_string p_len =
     let buf = Buffer.create (4 * List.length p_len) in
@@ -99,33 +103,28 @@ let to_buf t =
   in
   let contents =
     [
-      Bitv.L.to_string t.b;
-      gs;
-      string_of_int t.k;
-      gs;
-      p_len_to_string t.p_len;
-      gs;
-      string_of_int t.m;
+      Bytes.of_string (string_of_int t.k);
+      Bytes.of_string (p_len_to_string t.p_len);
+      Bytes.of_string (string_of_int t.m);
+      Bitv.to_bytes t.b;
     ]
   in
-  contents |> List.iter (Buffer.add_string buf);
+  contents |> List.iter (write_to_buf buf);
   buf
 
 let to_bytes t = to_buf t |> Buffer.to_bytes
 
-let to_string t = to_buf t |> Buffer.contents
-
 let unwrap_input_list error_message l =
   let rec aux l acc =
     match l with
-    | [] -> ( Ok (List.rev acc) [@explicit_arity] )
-    | ((Some x)[@explicit_arity]) :: tl -> aux tl (x :: acc)
-    | None :: _ -> ( Error error_message [@explicit_arity] )
+    | [] -> Ok (List.rev acc)
+    | Some x :: tl -> aux tl (x :: acc)
+    | None :: _ -> Error error_message
   in
   aux l []
 
-let int_of_string_opt inpt =
-  match int_of_string inpt with
+let int_of_bytes_opt inpt =
+  match int_of_string (Bytes.unsafe_to_string inpt) with
   | inpt_int -> Some inpt_int
   | exception Failure _ -> None
 
@@ -152,24 +151,64 @@ let parse_p_len p_len_str =
       |> List.map (fun p -> p |> String.split_on_char us |> parse_pair)
       |> unwrap_input_list "Invalid p_len pair(s)"
 
-let of_string s =
-  let gs = Char.chr 29 in
-  match String.split_on_char gs s with
-  | [ bv_str; k_str; p_len_str; m_str ] -> (
-      let b = Bitv.L.of_string bv_str in
-      match parse_p_len p_len_str with
+let nth_opt buf n =
+  match Buffer.nth buf n with
+  | c -> ( Some c [@explicit_arity] )
+  | exception Invalid_argument _ -> None
+
+let read_n_bytes n buf p =
+  let rec loop p n acc =
+    match n with
+    | n when n > 0 -> (
+        match nth_opt buf p with
+        | ((Some chr)[@explicit_arity]) ->
+            loop (p + 1) (n - 1)
+              (Bytes.concat Bytes.empty [ acc; Bytes.make 1 chr ])
+        | None -> acc )
+    | _ -> acc
+  in
+  loop (p + 1) n Bytes.empty
+
+let read_until from til buf =
+  let rec loop pos acc =
+    match Buffer.nth buf pos with
+    | cur when cur = til -> acc
+    | cur -> loop (pos + 1) (Bytes.cat acc (Bytes.make 1 cur))
+    | exception Invalid_argument _ -> acc
+  in
+  loop from Bytes.empty
+
+let of_buffer buf =
+  let separator = Char.chr 124 in
+  let rec parse_loop buf contents offset =
+    if offset >= Buffer.length buf then List.rev contents
+    else
+      let n_b = read_until offset separator buf in
+      let n_len = Bytes.length n_b in
+      let n = n_b |> Bytes.unsafe_to_string |> int_of_string in
+      let block_contents = read_n_bytes n buf (offset + n_len) in
+      let new_offset = offset + n_len + Bytes.length block_contents + 1 in
+      parse_loop buf (block_contents :: contents) new_offset
+  in
+  match parse_loop buf [] 0 with
+  | [ k_b; p_len_b; m_b; bv_b ] -> (
+      let b = Bitv.of_bytes bv_b in
+      match parse_p_len (Bytes.to_string p_len_b) with
       | Ok p_len -> (
-          let m = int_of_string_opt m_str in
-          let k = int_of_string_opt k_str in
+          let m = int_of_bytes_opt m_b in
+          let k = int_of_bytes_opt k_b in
           match (m, k) with
           | Some m, Some k -> Ok { m; k; p_len; b }
           | None, Some _ -> Error "Invalid int for 'm'"
           | Some _, None -> Error "Invalid int for 'k'"
-          | None, None -> Error "Invalid int for both 'm' and 'k'" )
+          | None, None -> Error "Invalid int for 'm' and 'k'" )
       | Error msg -> Error msg )
-  | _ -> Error "invalid number of fields in input"
+  | _ -> Error "Invalid number of fields in input"
 
-let of_bytes b = of_string (Bytes.to_string b)
+let of_bytes b =
+  let buf = Buffer.create (Bytes.length b) in
+  let () = Buffer.add_bytes buf b in
+  of_buffer buf
 
 module type Hashable = sig
   type t

--- a/src/bloomf.ml
+++ b/src/bloomf.ml
@@ -108,7 +108,7 @@ let to_buf t =
       string_of_int t.m;
     ]
   in
-  contents |> List.iter (fun s -> Buffer.add_string buf s);
+  contents |> List.iter (Buffer.add_string buf);
   buf
 
 let to_bytes t = to_buf t |> Buffer.to_bytes

--- a/src/bloomf.ml
+++ b/src/bloomf.ml
@@ -132,9 +132,9 @@ let int_of_string_opt inpt =
 let parse_p_len p_len_str =
   let rs = Char.chr 30 in
   let us = Char.chr 31 in
-  let parse_pair_ary pair =
+  let parse_pair pair =
     match pair with
-    | [| x; y |] -> (
+    | [ x; y ] -> (
         let x_opt = int_of_string_opt x in
         let y_opt = int_of_string_opt y in
         match (x_opt, y_opt) with
@@ -149,8 +149,7 @@ let parse_p_len p_len_str =
   | [ " " ] -> Ok []
   | p_len_lst ->
       p_len_lst
-      |> List.map (fun p ->
-             p |> String.split_on_char us |> Array.of_list |> parse_pair_ary)
+      |> List.map (fun p -> p |> String.split_on_char us |> parse_pair)
       |> unwrap_input_list "Invalid p_len pair(s)"
 
 let of_string s =

--- a/src/bloomf.ml
+++ b/src/bloomf.ml
@@ -78,137 +78,49 @@ let size_estimate t =
   let xf = float_of_int (Bitv.pop t.b) in
   int_of_float (-.mf /. kf *. log (1. -. (xf /. mf)))
 
-let to_buf t =
-  let rs = String.make 1 (Char.chr 30) in
-  let us = String.make 1 (Char.chr 31) in
-  let buf =
-    Buffer.create (5 + (4 * List.length t.p_len) + (2 * Bitv.length t.b))
+let to_bytes t =
+  let flat_p_len =
+    t.p_len |> List.fold_left (fun acc (a, b) -> a :: b :: acc) []
   in
-  let write_to_buf buf content =
-    Buffer.add_string buf (string_of_int (Bytes.length content));
-    Buffer.add_string buf "|";
-    Buffer.add_bytes buf content
-  in
-  let p_len_to_string p_len =
-    let buf = Buffer.create (4 * List.length p_len) in
-    ( match p_len with
-    | [] -> Buffer.add_string buf (" " ^ rs)
-    | p_len ->
-        p_len
-        |> List.iter (fun p ->
-               let fst, snd = p in
-               Buffer.add_string buf
-                 (string_of_int fst ^ us ^ string_of_int snd ^ rs)) );
-    buf |> Buffer.contents
-  in
-  let contents =
+  let first_to_encode = Array.of_list (t.m :: t.k :: flat_p_len) in
+  Bytes.concat Bytes.empty
     [
-      Bytes.of_string (string_of_int t.k);
-      Bytes.of_string (p_len_to_string t.p_len);
-      Bytes.of_string (string_of_int t.m);
+      Bytes.init
+        (8 * Array.length first_to_encode)
+        (fun i -> Char.chr ((first_to_encode.(i / 8) lsr (8 * i)) land 0xFF));
       Bitv.to_bytes t.b;
     ]
-  in
-  contents |> List.iter (write_to_buf buf);
-  buf
-
-let to_bytes t = to_buf t |> Buffer.to_bytes
-
-let unwrap_input_list error_message l =
-  let rec aux l acc =
-    match l with
-    | [] -> Ok (List.rev acc)
-    | Some x :: tl -> aux tl (x :: acc)
-    | None :: _ -> Error error_message
-  in
-  aux l []
-
-let int_of_bytes_opt inpt =
-  match int_of_string (Bytes.unsafe_to_string inpt) with
-  | inpt_int -> Some inpt_int
-  | exception Failure _ -> None
-
-let parse_p_len p_len_str =
-  let rs = Char.chr 30 in
-  let us = Char.chr 31 in
-  let parse_pair pair =
-    match pair with
-    | [ x; y ] -> (
-        let x_opt = int_of_string_opt x in
-        let y_opt = int_of_string_opt y in
-        match (x_opt, y_opt) with
-        | Some x_opt, Some y_opt -> Some (x_opt, y_opt)
-        | _ -> None )
-    | _ -> None
-  in
-  let p_len_lst =
-    p_len_str |> String.split_on_char rs |> List.filter (fun p -> p <> "")
-  in
-  match p_len_lst with
-  | [ " " ] -> Ok []
-  | p_len_lst ->
-      p_len_lst
-      |> List.map (fun p -> p |> String.split_on_char us |> parse_pair)
-      |> unwrap_input_list "Invalid p_len pair(s)"
-
-let nth_opt buf n =
-  match Buffer.nth buf n with
-  | c -> ( Some c [@explicit_arity] )
-  | exception Invalid_argument _ -> None
-
-let read_n_bytes n buf p =
-  let rec loop p n acc =
-    match n with
-    | n when n > 0 -> (
-        match nth_opt buf p with
-        | ((Some chr)[@explicit_arity]) ->
-            loop (p + 1) (n - 1)
-              (Bytes.concat Bytes.empty [ acc; Bytes.make 1 chr ])
-        | None -> acc )
-    | _ -> acc
-  in
-  loop (p + 1) n Bytes.empty
-
-let read_until from til buf =
-  let rec loop pos acc =
-    match Buffer.nth buf pos with
-    | cur when cur = til -> acc
-    | cur -> loop (pos + 1) (Bytes.cat acc (Bytes.make 1 cur))
-    | exception Invalid_argument _ -> acc
-  in
-  loop from Bytes.empty
-
-let of_buffer buf =
-  let separator = Char.chr 124 in
-  let rec parse_loop buf contents offset =
-    if offset >= Buffer.length buf then List.rev contents
-    else
-      let n_b = read_until offset separator buf in
-      let n_len = Bytes.length n_b in
-      let n = n_b |> Bytes.unsafe_to_string |> int_of_string in
-      let block_contents = read_n_bytes n buf (offset + n_len) in
-      let new_offset = offset + n_len + Bytes.length block_contents + 1 in
-      parse_loop buf (block_contents :: contents) new_offset
-  in
-  match parse_loop buf [] 0 with
-  | [ k_b; p_len_b; m_b; bv_b ] -> (
-      let b = Bitv.of_bytes bv_b in
-      match parse_p_len (Bytes.to_string p_len_b) with
-      | Ok p_len -> (
-          let m = int_of_bytes_opt m_b in
-          let k = int_of_bytes_opt k_b in
-          match (m, k) with
-          | Some m, Some k -> Ok { m; k; p_len; b }
-          | None, Some _ -> Error "Invalid int for 'm'"
-          | Some _, None -> Error "Invalid int for 'k'"
-          | None, None -> Error "Invalid int for 'm' and 'k'" )
-      | Error msg -> Error msg )
-  | _ -> Error "Invalid number of fields in input"
 
 let of_bytes b =
-  let buf = Buffer.create (Bytes.length b) in
-  let () = Buffer.add_bytes buf b in
-  of_buffer buf
+  let int_of_bytes b =
+    let rec build x i =
+      if i < 0 then x
+      else build ((x lsl 8) lor Char.code (Bytes.get b i)) (pred i)
+    in
+    build 0 7
+  in
+  let rec parse_p_len start stop acc last =
+    if start >= stop then (start, acc)
+    else
+      let next_value = int_of_bytes (Bytes.sub b start 8) in
+      match last with
+      | Some value ->
+          parse_p_len (start + 8) stop ((value, next_value) :: acc) None
+      | None -> parse_p_len (start + 8) stop acc (Some next_value)
+  in
+  match int_of_bytes (Bytes.sub b 0 8) with
+  | exception Invalid_argument _ -> Error "Failed to parse (m)"
+  | m -> (
+      match int_of_bytes (Bytes.sub b 8 8) with
+      | exception Invalid_argument _ -> Error "Failed to parse (k)"
+      | k -> (
+          (* 16 initial offset + 2 ints per entry in p_len (which has `k` elements) *)
+          match parse_p_len 16 (16 + (k * 16)) [] None with
+          | exception Invalid_argument _ -> Error "Failed to parse (p_len)"
+          | i, p_len -> (
+              match Bitv.of_bytes (Bytes.sub b i (Bytes.length b - i)) with
+              | exception Invalid_argument _ -> Error "Failed to parse (b)"
+              | b -> Ok { m; k; p_len; b } ) ) )
 
 module type Hashable = sig
   type t

--- a/src/bloomf.mli
+++ b/src/bloomf.mli
@@ -36,6 +36,14 @@ val size_estimate : 'a t -> int
     the bloom filter. Please note that this operation is costly (see
     benchmarks). *)
 
+val to_string : 'a t -> string
+
+val to_bytes : 'a t -> bytes
+
+val of_string : string -> 'a t
+
+val of_bytes : bytes -> 'a t
+
 (** {1 Functorial interface} *)
 
 (** The functorial interface allows you to specify your own hash function. *)

--- a/src/bloomf.mli
+++ b/src/bloomf.mli
@@ -37,12 +37,24 @@ val size_estimate : 'a t -> int
     benchmarks). *)
 
 val to_string : 'a t -> string
+(** [to_string t] converts a [t] to a [string] suitable for serialization to
+    file, disk, or similar.The string returned by this function should be
+    treated as an opaque datastructure. *)
 
 val to_bytes : 'a t -> bytes
+(** [to_bytes t] converts a [t] to [bytes]. The same concerns about
+    serialization apply here as to [to_string] *)
 
 val of_string : string -> ('a t, string) result
+(** [of_string t] converts a [string] of the format serialized by [to_string] to
+    [t]. It falls to the caller to handle the finer points of de-serialization
+    such as ensuring that the data structures remain consistent, that the hash
+    function (if provided) is the same (including possible random seed) etc *)
 
 val of_bytes : bytes -> ('a t, string) result
+(** [of_bytes t] converts a [bytes] of the format serialized by [to_bytes] to
+    [t]. All of the same concerns regarding deserialization and program state
+    apply to this function as they do to [to_string] *)
 
 (** {1 Functorial interface} *)
 

--- a/src/bloomf.mli
+++ b/src/bloomf.mli
@@ -40,9 +40,9 @@ val to_string : 'a t -> string
 
 val to_bytes : 'a t -> bytes
 
-val of_string : string -> 'a t
+val of_string : string -> ('a t, string) result
 
-val of_bytes : bytes -> 'a t
+val of_bytes : bytes -> ('a t, string) result
 
 (** {1 Functorial interface} *)
 

--- a/src/bloomf.mli
+++ b/src/bloomf.mli
@@ -36,20 +36,9 @@ val size_estimate : 'a t -> int
     the bloom filter. Please note that this operation is costly (see
     benchmarks). *)
 
-val to_string : 'a t -> string
-(** [to_string t] converts a [t] to a [string] suitable for serialization to
-    file, disk, or similar.The string returned by this function should be
-    treated as an opaque datastructure. *)
-
 val to_bytes : 'a t -> bytes
 (** [to_bytes t] converts a [t] to [bytes]. The same concerns about
     serialization apply here as to [to_string] *)
-
-val of_string : string -> ('a t, string) result
-(** [of_string t] converts a [string] of the format serialized by [to_string] to
-    [t]. It falls to the caller to handle the finer points of de-serialization
-    such as ensuring that the data structures remain consistent, that the hash
-    function (if provided) is the same (including possible random seed) etc *)
 
 val of_bytes : bytes -> ('a t, string) result
 (** [of_bytes t] converts a [bytes] of the format serialized by [to_bytes] to

--- a/test/main.ml
+++ b/test/main.ml
@@ -60,19 +60,16 @@ let test_size () =
         Alcotest.failf "size_estimate: expecting@\n%d, got@\n%d" i len)
     sizes
 
-let test_string_roundtrip () =
-  let bf = Bloomf.create ~error_rate:expected_error_rate 1 in
-  let () = Bloomf.add bf "test_string" in
-  let bf2 = Bloomf.of_string (Bloomf.to_string bf) in
-  match bf2 with
-  | Ok b -> if bf <> b then Alcotest.fail "Decoded objects unequal" else ()
+let test_bytes_roundtrip () =
+  match Bloomf.of_bytes (Bloomf.to_bytes bf) with
+  | Ok b -> if bf = b then () else Alcotest.fail "Decoded objects unequal"
   | Error msg -> Alcotest.failf "of_string failed to decode object: %s\n" msg
 
 let test_set =
   [
     ("Mem returns true when element was added", `Quick, test_mem);
     ("Mem returns false when filter is empty", `Quick, test_mem_create);
-    ("String roundtrip equality", `Quick, test_string_roundtrip);
+    ("Bytes roundtrip equality", `Quick, test_bytes_roundtrip);
     ( "False positive rate is as specified (15% error allowed)",
       `Slow,
       test_errors );

--- a/test/main.ml
+++ b/test/main.ml
@@ -65,11 +65,19 @@ let test_bytes_roundtrip () =
   | Ok b -> if bf = b then () else Alcotest.fail "Decoded objects unequal"
   | Error msg -> Alcotest.failf "of_string failed to decode object: %s\n" msg
 
+let test_invalid_bytes () =
+  match Bloomf.of_bytes (Bytes.init 17 (fun i -> Char.chr i)) with
+  | Ok _ -> Alcotest.fail "Ok result for of_bytes on invalid input"
+  | Error _ -> ()
+
 let test_set =
   [
     ("Mem returns true when element was added", `Quick, test_mem);
     ("Mem returns false when filter is empty", `Quick, test_mem_create);
-    ("Bytes roundtrip equality", `Quick, test_bytes_roundtrip);
+    ( "Roundtrip to/of bytes returns same structure",
+      `Quick,
+      test_bytes_roundtrip );
+    ("of_bytes returns Error on invalid input", `Quick, test_invalid_bytes);
     ( "False positive rate is as specified (15% error allowed)",
       `Slow,
       test_errors );

--- a/test/main.ml
+++ b/test/main.ml
@@ -60,10 +60,19 @@ let test_size () =
         Alcotest.failf "size_estimate: expecting@\n%d, got@\n%d" i len)
     sizes
 
+let test_string_roundtrip () =
+  let bf = Bloomf.create ~error_rate:expected_error_rate 1 in
+  let () = Bloomf.add bf "test_string" in
+  let bf2 = Bloomf.of_string (Bloomf.to_string bf) in
+  match bf2 with
+  | Ok b -> if bf <> b then Alcotest.fail "Decoded objects unequal" else ()
+  | Error msg -> Alcotest.failf "of_string failed to decode object: %s\n" msg
+
 let test_set =
   [
     ("Mem returns true when element was added", `Quick, test_mem);
     ("Mem returns false when filter is empty", `Quick, test_mem_create);
+    ("String roundtrip equality", `Quick, test_string_roundtrip);
     ( "False positive rate is as specified (15% error allowed)",
       `Slow,
       test_errors );


### PR DESCRIPTION
Begins to address #6.
Some family matters will keep me from revisiting this this weekend, but this builds locally.
I'll still need to add documentation and tests for the added functionality.

Mostly opening early for feedback on the implementation.
I've chosen to go with `Buffers` internally, as they are relatively fast (from what I have read) and easily convert between bytes and strings.
The imperative nature of working with them is frustrating though.
This can be refactored pretty easily with a `String` based interface, if desired.

You'll notice that I didn't use `Bitv.output_bin`.
It only accepts channels and creating a memory-backed channel seemed quite daunting.
Instead, I just used `Bitv.to_list` and re-used some of the logic that {de,}serializes `p_len`.