### PR TITLE
Union and intersection

### DIFF
--- a/src/bloomf.ml
+++ b/src/bloomf.ml
@@ -57,6 +57,15 @@ let add_priv t hashed_data =
 
 let add bf data = add_priv bf (Hashtbl.hash data)
 
+let op f bf1 bf2 =
+  if bf1.k = bf2.k && bf1.m = bf2.m then
+    Some { m=bf1.m; k= bf2.k; p_len=bf1.p_len; b=f bf1.b bf2.b }
+  else None
+
+let union bf1 bf2 = op Bitv.bw_or bf1 bf2
+
+let intersection bf1 bf2 = op Bitv.bw_and bf1 bf2
+
 let mem_priv t hashed_data =
   let rec loop = function
     | [] -> true

--- a/src/bloomf.mli
+++ b/src/bloomf.mli
@@ -31,6 +31,26 @@ val mem : 'a t -> 'a -> bool
 val clear : 'a t -> unit
 (** [clear t] clears the contents of [t]. *)
 
+val union : 'a t -> 'a t -> 'a t option
+(** [union t1 t2] computes the union of the two inputs. This operation is
+    lossless in the sense that the resulting Bloom filter is the same as
+    the Bloom filter created from scratch using the union of the two sets.
+
+    The output is [Some] if the two inputs were created using the same
+    error rate and size.
+*)
+
+val intersection : 'a t -> 'a t -> 'a t option
+(** [intersection t1 t2] computes the intersection of the two inputs. The false positive
+    probability in the resulting Bloom filter is at most the false-positive probability
+    in one of the constituent Bloom filters, but may be larger than the false positive
+    probability in the Bloom filter created from scratch using the intersection of the
+    two sets.
+
+    The output is [Some] if the two inputs were created using the same
+    error rate and size.
+*)
+
 val size_estimate : 'a t -> int
 (** [size_estimate t] is an approximation of the number of elements stored in
     the bloom filter. Please note that this operation is costly (see


### PR DESCRIPTION
This PR adds union and intersection for bloom filters with the same number of hash functions and buckets.

Most of the comment text is taken from [here](https://en.wikipedia.org/wiki/Bloom_filter#Interesting_properties). Let me know if there should be a citation.